### PR TITLE
Swaps positions of the "confirm" and "cancel" buttons in the dialogue window for better usability.

### DIFF
--- a/extension/super-export.lua
+++ b/extension/super-export.lua
@@ -216,14 +216,6 @@ local function mainWindow()
     }
 
     dialog:button {
-        id="cancel",
-        text="Cancel",
-        onclick=function()
-            dialog:close()
-        end
-    }
-
-    dialog:button {
         id="confirm",
         text="Confirm",
         onclick=function()
@@ -237,6 +229,14 @@ local function mainWindow()
             -- show the dialog to the user
             dialog:close()
             processExport(props)
+        end
+    }
+
+    dialog:button {
+        id="cancel",
+        text="Cancel",
+        onclick=function()
+            dialog:close()
         end
     }
 


### PR DESCRIPTION
Hi! Love your plugin. But there is some thing I changed for myself locally and thought maybe you would be interested to see it.

When I use the "Super Export", the dialogue window opens up, and its more handful if the "Confirm" button is right below the percentage input field.

![image](https://user-images.githubusercontent.com/106176669/176272531-81d7d72c-61cf-4ef4-b24a-18b778f9a5b9.png)

For example, here how the buttons in the default Aseprite Export tool are positioned:
![image](https://user-images.githubusercontent.com/106176669/176273085-18ec9aa7-f63f-42e2-b9ce-97cdd53cfed7.png)


Also! The "On the following window, set the percentage at 100%." is quite annoying to click on every time i export images. Could you please add a "never show again" button on it or just delete it (and possibly add this as a description in the dialogue window)
